### PR TITLE
docs: #35 README 링크 및 private 설정 수정

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "https://github.com/minwoo129/fetoolkit",
+  "homepage": "https://github.com/minwoo129/fetoolkit/tree/main/packages/react",
   "repository": {
     "type": "git",
     "url": "https://github.com/minwoo129/fetoolkit.git"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fetoolkit/react",
   "version": "1.2.1",
+  "private": false,
   "type": "module",
   "author": "minwoo129 <key0129mw@naver.com>",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "homepage": "https://github.com/minwoo129/fetoolkit",
+  "homepage": "https://github.com/minwoo129/fetoolkit/tree/main/packages/utils",
   "repository": {
     "type": "git",
     "url": "https://github.com/minwoo129/fetoolkit.git"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@fetoolkit/utils",
   "version": "1.2.1",
+  "private": false,
   "type": "module",
   "author": "minwoo129 <key0129mw@naver.com>",
   "license": "MIT",


### PR DESCRIPTION
## 📝 변경사항

이 PR은 이슈 #35를 해결하기 위해 다음과 같은 변경사항을 포함합니다:

### 🔧 Package.json 수정
- **`packages/react/package.json`**
  - `"private": false` 추가
  - `homepage` 필드를 `https://github.com/minwoo129/fetoolkit/tree/main/packages/react`로 수정

- **`packages/utils/package.json`**
  - `"private": false` 추가  
  - `homepage` 필드를 `https://github.com/minwoo129/fetoolkit/tree/main/packages/utils`로 수정

### 🎯 목적
- 각 패키지의 README 링크가 올바른 디렉토리로 연결되도록 개선
- 패키지가 공개적으로 사용 가능하도록 `private: false` 설정 추가

### ✅ 테스트
- [x] package.json 파일의 문법 검증 완료
- [x] homepage 링크가 올바른 경로를 가리키는지 확인

## 관련 이슈
Closes #35