### PR TITLE
[DOCS] README에 admin-react 패키지 정보 추가 (v2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ FEToolkit is a toolkit library that provides useful functions for Frontend devel
 
 ## Modules
 
-| Name  | Description                   |                          Downloads                          |           GitHub            |
-| :---- | :---------------------------- | :---------------------------------------------------------: | :-------------------------: |
-| react | package for react             | [Downloads](https://www.npmjs.com/package/@fetoolkit/react) | [GitHub](./packages/react/) |
-| utils | package for utility functions | [Downloads](https://www.npmjs.com/package/@fetoolkit/utils) | [GitHub](./packages/utils/) |
+| Name        | Description                                                            |                          Downloads                          |              GitHub               |
+| :---------- | :--------------------------------------------------------------------- | :---------------------------------------------------------: | :-------------------------------: |
+| react       | package for react                                                      | [Downloads](https://www.npmjs.com/package/@fetoolkit/react) |    [GitHub](./packages/react/)    |
+| utils       | package for utility functions                                          | [Downloads](https://www.npmjs.com/package/@fetoolkit/utils) |    [GitHub](./packages/utils/)    |
+| admin-react | package for provide useful features when develop admin site(for react) |                          Downloads                          | [GitHub](./packages/admin-react/) |

--- a/README_kr.md
+++ b/README_kr.md
@@ -10,7 +10,8 @@ FEToolkit은 Frontend 개발 시 유용하게 사용할 수 있는 기능들을 
 
 ## 제공 모듈
 
-| Name  | Description                      |                          Downloads                          |           GitHub            |
-| :---- | :------------------------------- | :---------------------------------------------------------: | :-------------------------: |
-| react | react 전용 패키지입니다.         | [Downloads](https://www.npmjs.com/package/@fetoolkit/react) | [GitHub](./packages/react/) |
-| utils | 유틸리티 함수 전용 패키지입니다. | [Downloads](https://www.npmjs.com/package/@fetoolkit/utils) | [GitHub](./packages/utils/) |
+| Name        | Description                                                                              |                          Downloads                          |              GitHub               |
+| :---------- | :--------------------------------------------------------------------------------------- | :---------------------------------------------------------: | :-------------------------------: |
+| react       | react 전용 패키지입니다.                                                                 | [Downloads](https://www.npmjs.com/package/@fetoolkit/react) |    [GitHub](./packages/react/)    |
+| utils       | 유틸리티 함수 전용 패키지입니다.                                                         | [Downloads](https://www.npmjs.com/package/@fetoolkit/utils) |    [GitHub](./packages/utils/)    |
+| admin-react | 관리자 페이지 개발시 유용한 컴포넌트, hook, 함수 등을 제공하는 패키지입니다.(react 전용) |                          Downloads                          | [GitHub](./packages/admin-react/) |


### PR DESCRIPTION
## 이슈번호

- #82

## Description

README 문서에 admin-react 패키지 정보를 추가하여 프로젝트의 전체 모듈 구조를 명확히 표시

- README.md에 admin-react 패키지 모듈 정보 추가
- README_kr.md에 admin-react 패키지 모듈 정보 추가
- 테이블 형식으로 모듈별 설명, 다운로드 링크, GitHub 링크 정리