### PR TITLE
[FEAT] GitHub Actions CI/CD 배포 파이프라인 수정(v2.0.0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,12 @@ on:
   push:
     branches:
       - release
+permissions:
+  id-token: write
+  contents: read
 jobs:
   publish-to-npm:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,5 +34,3 @@ jobs:
           git add .
           git commit -m "temp commit"
           yarn lerna publish from-package --yes
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 이슈번호

- #122

## Description

- GitHub Actions CI/CD 배포 파이프라인 수정
    - npm에서 기존 클래식 토큰 방식이 다음달부터 지원종료된다고 하여 파이프라인 수정을 통한 후속조치 
    - npm에서 각 패키지 설정화면에 레포지토리와 배포하는 CI/CD 파이프라인 파일명을 등록하면 토큰 없이 배포가 가능하다고 함
        - 참고: [npm 공식문서 - CI/CD 워크플로우 작성](https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow)

## 변경사항

- 퍼블리시 CI/CD 워크플로우 수정